### PR TITLE
Update enabled flag for IE9 compatibility & preservation of existing cookies

### DIFF
--- a/src/jquery.cookie.js
+++ b/src/jquery.cookie.js
@@ -103,14 +103,12 @@
 	};
 
 	$.cookie.enabled = (function() {
-		var enabled = navigator.cookieEnabled;
-
-		if(typeof enabled === undefined && !enabled) {
-			document.cookie = 'test';
-			enabled = (document.cookie.indexOf('test') !== -1) ? true : false;
+		$.cookie("cookieEnabledCheck", "set");
+		if($.cookie("cookieEnabledCheck") !== "set") {
+			return false;
 		}
-
-		return enabled;
+		$.removeCookie("cookieEnabledCheck");
+		return true;
 	})();
 
 	config.defaults = {};

--- a/src/jquery.cookie.js
+++ b/src/jquery.cookie.js
@@ -102,15 +102,6 @@
 		return result;
 	};
 
-	$.cookie.enabled = (function() {
-		$.cookie("cookieEnabledCheck", "set");
-		if($.cookie("cookieEnabledCheck") !== "set") {
-			return false;
-		}
-		$.removeCookie("cookieEnabledCheck");
-		return true;
-	})();
-
 	config.defaults = {};
 
 	$.removeCookie = function (key, options) {
@@ -122,4 +113,13 @@
 		$.cookie(key, '', $.extend({}, options, { expires: -1 }));
 		return !$.cookie(key);
 	};
+	
+	$.cookie.enabled = (function() {
+		$.cookie("cookieEnabledCheck", "set");
+		if($.cookie("cookieEnabledCheck") !== "set") {
+			return false;
+		}
+		$.removeCookie("cookieEnabledCheck");
+		return true;
+	})();
 }));


### PR DESCRIPTION
I like the idea of an `enabled` property for cookies as I do this check myself, but this implementation has a few flaws:
- `navigator.cookiesEnabled` always returns true in IE9
- On a page which has cookies enabled _and_ has previously set cookies, the code will remove all those previously set values by overwriting the `document.cookie`
- Perhaps this was intended, but the `test` value is left in the user's cookies if a test succeeds. If you need to check if cookies are enabled, you probably want to check on every load.

The suggested replacement uses `$.cookie`s internal methods for setting a cookie, checking to see if it is set, then removing it again when finished.
